### PR TITLE
Added new `dapi` component in FindDOOCS.cmake module.

### DIFF
--- a/cmake/Modules/FindDOOCS.cmake
+++ b/cmake/Modules/FindDOOCS.cmake
@@ -44,6 +44,13 @@ if (";${DOOCS_FIND_COMPONENTS};" MATCHES ";zmq;")
   set(DOOCS_LIBRARIES ${DOOCS_LIBRARIES} DOOCSdzmq)
 endif()
 
+if (";${DOOCS_FIND_COMPONENTS};" MATCHES ";dapi;")
+  FIND_PATH(DOOCS_DIR_DAPI libDOOCSdapi.so
+    ${DOOCS_DIR}
+  )
+  set(DOOCS_LIBRARIES ${DOOCS_LIBRARIES} DOOCSdapi)
+endif()
+
 if (";${DOOCS_FIND_COMPONENTS};" MATCHES ";server;")
   FIND_PATH(DOOCS_DIR_SERVER libEqServer.so
     ${DOOCS_DIR}


### PR DESCRIPTION
The component is actually a DOOCSdapi library, which is a set of properties implementing client library utility. It is used in several servers of mine and others may find it useful as well.

The change was tested and it properly fetches the library path.