### PR TITLE
Ignore configuration files for Visual Studio Code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build
 .project
 .kdev4
 *.kdev4
+.vscode
 #files ending with ~ are emacs backups
 *~
 #files ending with .swp might show up when using vi


### PR DESCRIPTION
This subject says it all. The `.vscode` directory should be included in `.gitignore` so that files used when developing with Visual Studio Code are ignored.