### PR TITLE
Ignore files generated by CMake during configure

### DIFF
--- a/cmake/enable_code_style_check.cmake
+++ b/cmake/enable_code_style_check.cmake
@@ -18,5 +18,5 @@
 #######################################################################################################################
 
 enable_testing()
-add_test(NAME coding_style COMMAND ${CMAKE_SOURCE_DIR}/cmake/check-coding-style.sh
+add_test(NAME coding_style COMMAND ${CMAKE_SOURCE_DIR}/cmake/check-coding-style.sh ${CMAKE_BINARY_DIR}
                            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
There are a couple of files in the CMakeFiles folder that will match the
search patterns. This is problematic during package build, since debian
builds in a subfolder of the source folder, so we hit those files and
tests fail