### PR TITLE
fix: remove extra rpath from DOOCS imported targets

### DIFF
--- a/cmake/Modules/FindDOOCS.cmake
+++ b/cmake/Modules/FindDOOCS.cmake
@@ -38,7 +38,7 @@
 
 SET(DOOCS_FOUND 0)
 
-# if set, include the --no-as-needed linker flag which helps if inner dependencies between libs are not properly 
+# if set, include the --no-as-needed linker flag which helps if inner dependencies between libs are not properly
 # set inside the library binaries
 set(DOOCS_noAsNeededFlag 1)
 
@@ -59,7 +59,7 @@ if (NOT DOOCS_FIND_QUIETLY)
     message("FindDOOCS: Using PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}")
 endif()
 
-# We add the always - required API component 
+# We add the always - required API component
 if (NOT (";${DOOCS_FIND_COMPONENTS};" MATCHES ";api;"))
     list(PREPEND DOOCS_FIND_COMPONENTS "api")
 endif()
@@ -108,8 +108,9 @@ foreach(component ${DOOCS_FIND_COMPONENTS})
                 message(STATUS "FindDOOCS: imported target is ${importedTarget}. Defining alias DOOCS::${component}")
             endif()
             add_library(DOOCS::${component} ALIAS ${importedTarget})
+
             set(DOOCS_LIBRARIES ${DOOCS_LIBRARIES} "DOOCS::${component}")
-            
+
             if (${component} STREQUAL "api")
                 # add Threads lib only if not yet in
                 get_target_property(doocsLinkLibs ${importedTarget} INTERFACE_LINK_LIBRARIES)
@@ -128,7 +129,21 @@ foreach(component ${DOOCS_FIND_COMPONENTS})
                 string(REGEX REPLACE ".*-NOTFOUND" "" doocsLinkLibs "${doocsLinkLibs}")
                 set_target_properties(${importedTarget} PROPERTIES INTERFACE_LINK_LIBRARIES "DOOCS::api;${doocsLinkLibs}")
             endif()
-            
+
+            # strip the RPATH from the INTERFACE_LINK_OPTIONS of the imported target
+            # cmake will handle the RPATH properly itself when using imported targets. Adding the rpath linker flags
+            # explicitly will not only add the directories to the RPATH twice but also destroy the proper ordering,
+            # since the directories from the linker flags will be added first and e.g. the build directory will end up
+            # too late in the list. As a consequence, test executables might use the installed libraries instead of the
+            # library under test from the build directory - even for tests and libraries quite unrelated to DOOCS, as
+            # long as they have a DOOCS library as a (direct or indirect) dependency.
+            get_target_property(MY_LINK_OPTIONS ${importedTarget} INTERFACE_LINK_OPTIONS)
+            string(REGEX REPLACE "-Wl,-rpath,[^;]*" "" MY_LINK_OPTIONS "${MY_LINK_OPTIONS}")
+            string(REGEX REPLACE ";;" ";" MY_LINK_OPTIONS "${MY_LINK_OPTIONS}")
+            string(REGEX REPLACE "^;" "" MY_LINK_OPTIONS "${MY_LINK_OPTIONS}")
+            string(REGEX REPLACE ";$" "" MY_LINK_OPTIONS "${MY_LINK_OPTIONS}")
+            set_target_properties(${importedTarget} PROPERTIES INTERFACE_LINK_OPTIONS "${MY_LINK_OPTIONS}")
+
             # print some info about targets
             get_target_property(doocsIncDirs ${importedTarget} INTERFACE_INCLUDE_DIRECTORIES)
             message(VERBOSE "  include dirs: ${doocsIncDirs}")
@@ -140,7 +155,7 @@ foreach(component ${DOOCS_FIND_COMPONENTS})
             message(VERBOSE "  link libs: ${doocsLinkLibs}")
             get_target_property(doocsLinkDirs ${importedTarget} INTERFACE_LINK_DIRECTORIES)
             message(VERBOSE "  link dirs: ${doocsLinkDirs}")
-       
+
         else()
             message(FATAL_ERROR "DOOCS component ${component} not found!")
         endif()
@@ -176,7 +191,7 @@ macro(DOOCS_appendListToList list arg)
     endforeach()
 endmacro()
 
-# note, pkg_check_modules output variables <prefix>_VERSION and <prefix>_LIBDIR are different, 
+# note, pkg_check_modules output variables <prefix>_VERSION and <prefix>_LIBDIR are different,
 # depending on length of given module list!
 set(DOOCS_DIR "${DOOCS_api_LIBDIR}")
 set(DOOCS_VERSION "${DOOCS_api_VERSION}")
@@ -204,4 +219,4 @@ set(DOOCS_LINK_FLAGS ${DOOCS_LINKER_FLAGS})
 
 # use a macro provided by CMake to check if all the listed arguments are valid and set DOOCS_FOUND accordingly
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(DOOCS REQUIRED_VARS DOOCS_DIR VERSION_VAR DOOCS_VERSION )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(DOOCS REQUIRED_VARS DOOCS_DIR VERSION_VAR DOOCS_VERSION)


### PR DESCRIPTION
This should fix problems with additional RPATH in e.g. test executables linking (directly or indirectly) against DOOCS libraries. The DOOCS library path was set via the linker flags in the imported targets and hence ending up always first in the resulting RPATH, even before the build directory. cmake seems to append the library paths to the RPATH of the target binaries later, not via the linker flags (no rpath flags are visible in the linker command line). Hence explicit RPATH handling is unnecessary and even bug prone.