### PR TITLE
fix: Pass build dir to linter

### DIFF
--- a/cmake/add_linter_target.cmake
+++ b/cmake/add_linter_target.cmake
@@ -5,9 +5,9 @@ if (CTK_ENABLE_TIDY_WHILE_BUILDING)
     set(CMAKE_C_CLANG_TIDY /usr/bin/clang-tidy-${CTK_CLANG_TIDY_VERSION};-config-file=${CMAKE_SOURCE_DIR}/.clang-tidy)
 endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-add_custom_target(run-linter COMMAND run-clang-tidy-${CTK_CLANG_TIDY_VERSION} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(run-linter COMMAND run-clang-tidy-${CTK_CLANG_TIDY_VERSION} -p ${CMAKE_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_custom_target(fix-linter-stepwise COMMAND ${CMAKE_SOURCE_DIR}/cmake/fix-linter-for-all.py --tidy=clang-tidy-${CTK_CLANG_TIDY_VERSION} --apply-tool=clang-apply-replacements-${CTK_CLANG_TIDY_VERSION} --exclude="${CMAKE_BINARY_DIR}" ${CMAKE_BINARY_DIR}/compile_commands.json
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-add_custom_target(fix-linter COMMAND run-clang-tidy-${CTK_CLANG_TIDY_VERSION} -fix -format WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+add_custom_target(fix-linter COMMAND run-clang-tidy-${CTK_CLANG_TIDY_VERSION} -fix -format -p ${CMAKE_BINARY_DIR} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 


### PR DESCRIPTION
It is not possible to pass a config file to run-clang-tidy-14 so
previously the work dir was switched to the source folder for it to pick
up the .clang-tidy file automatically.

However that broke if the build folder was outside of the source folder
