### PR TITLE
Follow symlinks during build system generation

### DIFF
--- a/cmake/config_generator_project.cmake
+++ b/cmake/config_generator_project.cmake
@@ -27,7 +27,10 @@ set(DESTDIR share/ConfigGenerator-${PROJECT_NAME}-${${PROJECT_NAME}_MAJOR_VERSIO
 file(GLOB hostlists RELATIVE ${PROJECT_SOURCE_DIR} */hostlist)
 foreach(hostlist ${hostlists})
   string(REPLACE "/hostlist" "" servertype "${hostlist}")
-  file(COPY "${PROJECT_SOURCE_DIR}/${servertype}" DESTINATION "${PROJECT_BINARY_DIR}")
+  # FOLLOW_SYMLINK_CHAIN is necessary to allow symlinks to git-submodules. This is used to create
+  # "derived" configurations which reuse some files from their base configuration (example: configs for
+  # different control systems)
+  file(COPY "${PROJECT_SOURCE_DIR}/${servertype}" DESTINATION "${PROJECT_BINARY_DIR}" FOLLOW_SYMLINK_CHAIN)
   list(APPEND servertypes "${servertype}")
 endforeach()
 


### PR DESCRIPTION
Instead of copying a symlink file, resulting in a broken link, the target file is copied instead, unless the target is in the same directory, in which case the symlink is maintained.