### PR TITLE
chore(project-template): improve clang-format include sorting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -64,18 +64,18 @@ IncludeBlocks: 'Regroup'
 IncludeCategories:
   - Regex:           '^<ChimeraTK/'
     Priority:        2
-    SortPriority:    2
     CaseSensitive:   true
   - Regex:           '^<boost/'
-    Priority:        3
-    SortPriority:    3
-    CaseSensitive:   true
-  - Regex:           '<[[:alnum:].]+>'
     Priority:        4
-    SortPriority:        4
-  - Regex:           '.*'
+    CaseSensitive:   true
+  - Regex:           '^<.*/'
+    Priority:        3
+  - Regex:           '^".*"'
     Priority:        1
-    SortPriority:    0
+  - Regex:           '^<[[:alnum:]_]+>'
+    Priority:        6
+  - Regex:           '^<.*>'
+    Priority:        5
 SortUsingDeclarations: 'false'
 SpaceAfterCStyleCast: 'false'
 SpaceAfterTemplateKeyword: 'false'


### PR DESCRIPTION
This should group include directives like this:
1. corresponding header for the .cc file (if applicable)
2. include directives using quotes (i.e. non-system headers)
3. ChimeraTK system headers
4. System headers with a slash (except boost and ChimeraTK)
5. boost system headers
6. standard C-style system headers (with a dot but no slash)
7. standard C++-style system headers (no slash no dot)