### PR TITLE
chore(project-template): disable -Warray-bounds and -Wstringop-overflow

### DIFF
--- a/cmake/set_default_flags.cmake
+++ b/cmake/set_default_flags.cmake
@@ -24,7 +24,9 @@
 include(cmake/enable_latest_cxx_support.cmake)
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;asan;tsan")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${${PROJECT_NAME}_CXX_FLAGS} -Wall -Wextra -Wshadow -pedantic -Wuninitialized")
+# array-bounds and stringop-overflow warnings have many false positives in gcc 13.3 release builds (e.g. with
+# nlohman/json)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${${PROJECT_NAME}_CXX_FLAGS} -Wall -Wextra -Wshadow -pedantic -Wuninitialized -Wno-array-bounds -Wno-stringop-overflow")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -g")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0")


### PR DESCRIPTION
Those checks seem to be broken on gcc 13.3.